### PR TITLE
Added code to normalize endlines and added some customization options

### DIFF
--- a/starch.py
+++ b/starch.py
@@ -571,7 +571,7 @@ class Generator(object):
 
     def render(self, template_path, output_path, **kwargs):
         t = self.templates.get_template(template_path)
-        result = t.render(gen=self, current_dir=os.path.dirname(output_path), **kwargs)
+        result = t.render(gen=self, current_dir=os.path.dirname(output_path), **kwargs).replace('\r\n', '\n')
 
         if os.path.exists(output_path):
             with open(output_path, 'r') as f:

--- a/templates/benchmark.c.template
+++ b/templates/benchmark.c.template
@@ -15,8 +15,14 @@
 #include <unistd.h>
 #include <errno.h>
 
-#ifdef STARCH_COMPAT_REQUIRED
-#  include "compat.h"
+//On Windows platform, separate functions for allocating and freeing aligned memory must be used
+#ifdef _WIN32
+#  include <malloc.h>
+#  define util_aligned_alloc(alignment,size) (_aligned_malloc(size, alignment))
+#  define util_aligned_free(ptr) (_aligned_free(ptr))
+#else
+#  define util_aligned_alloc(alignment,size) (aligned_alloc(alignment,size))
+#  define util_aligned_free(ptr) (free(ptr))
 #endif
 
 #include "${os.path.relpath(gen.generated_include_path, current_dir)}"
@@ -83,7 +89,7 @@ void *starch_benchmark_aligned_alloc(size_t alignment, size_t type_alignment, si
      * of a more restrictive larger alignment)
      */
     size_t header_size = (use_alignment < sizeof(void*) ? sizeof(void*) : use_alignment);
-    char *block_ptr = aligned_alloc(use_alignment, header_size + size + use_alignment);
+    char *block_ptr = util_aligned_alloc(use_alignment, header_size + size + use_alignment);
     if (!block_ptr) {
         fprintf(stderr, "STARCH_BENCHMARK_ALLOC of %zu bytes failed: %s\n", size, strerror(errno));
         return NULL;
@@ -106,7 +112,7 @@ void starch_benchmark_aligned_free(void *user_ptr)
     if (!user_ptr)
         return;
     void **stash = (void**)user_ptr - 1;
-    free(*stash);
+    util_aligned_free(*stash);
 }
 
 static bool starch_benchmark_flavor_in_list(const char *flavor, const starch_benchmark_flavor_list *list)

--- a/templates/benchmark.c.template
+++ b/templates/benchmark.c.template
@@ -15,6 +15,10 @@
 #include <unistd.h>
 #include <errno.h>
 
+#ifdef STARCH_COMPAT_REQUIRED
+#  include "compat.h"
+#endif
+
 #include "${os.path.relpath(gen.generated_include_path, current_dir)}"
 
 typedef struct timespec starch_benchmark_time;

--- a/templates/makefile.template
+++ b/templates/makefile.template
@@ -21,6 +21,7 @@
 #  $(STARCH_BENCHMARK_OBJ): object files providing a standalone benchmarking app (link all of $(STARCH_OBJS) too)
 #  explicit build rules for each object file listed in $(STARCH_OBJS)
 
+MKDIR_P = mkdir -p
 STARCH_CFLAGS := -D${mix.macro}
 <%
    import os
@@ -35,7 +36,8 @@ STARCH_CFLAGS := -D${mix.macro}
    o_files.append(o_file)
 %>
 ${o_file}: ${c_file} ${impl_c_files}
-	$(STARCH_COMPILE) $(STARCH_CFLAGS) ${flavor.cflags} ${c_file} -o ${o_file}
+	@$(MKDIR_P) $(dir $(STARCH_OBJ_PATH)${o_file})
+	$(STARCH_COMPILE) $(STARCH_CFLAGS) ${flavor.cflags} ${c_file} -o $(STARCH_OBJ_PATH)${o_file}
 % endfor
 <%
    c_file = os.path.relpath(gen.generated_dispatcher_path, gen.runtime_dir)
@@ -43,7 +45,8 @@ ${o_file}: ${c_file} ${impl_c_files}
    o_files.append(o_file)
  %>
 ${o_file}: ${c_file} ${impl_c_files}
-	$(STARCH_COMPILE) $(STARCH_CFLAGS) ${c_file} -o ${o_file}
+	@$(MKDIR_P) $(dir $(STARCH_OBJ_PATH)${o_file})
+	$(STARCH_COMPILE) $(STARCH_CFLAGS) ${c_file} -o $(STARCH_OBJ_PATH)${o_file}
 
 STARCH_OBJS := ${' '.join(o_files)}
 
@@ -52,6 +55,7 @@ STARCH_OBJS := ${' '.join(o_files)}
    o_file = os.path.splitext(c_file)[0] + '.o'
  %>
 ${o_file}: ${c_file} ${benchmark_c_files}
-	$(STARCH_COMPILE) $(STARCH_CFLAGS) ${c_file} -o ${o_file}
+	@$(MKDIR_P) $(dir $(STARCH_OBJ_PATH)${o_file})
+	$(STARCH_COMPILE) $(STARCH_CFLAGS) ${c_file} -o $(STARCH_OBJ_PATH)${o_file}
 
 STARCH_BENCHMARK_OBJ := ${o_file}


### PR DESCRIPTION
Added a definition called STARCH_COMPAT_REQUIRED to the benchmark file template to specify whether a compat file is required or not.
Modified the Makefile template to make it possible to specify the output object file path.
Added code to normalize endlines so that the behavior is consistent on different platforms.